### PR TITLE
Structured Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,86 @@ npx @modelcontextprotocol/inspector
 
 ## DataToolOutput
 
-This MCP Server has a `ValidationModel` for the return type of the tools it will register. The goal of the `ValidationModel` and the `DataToolOutput` annotation
-is to have a standarized communication between plugins and server. The schema is still on development so changes are expected.
+This MCP Server uses a `DataToolOutput` annotation and a `ValidationModel` to enforce a standardized contract between plugins and the server. The schema is still in development so changes are expected.
 
-Because Python is a dynamically typed language we can only validate function signatures at startup time. This means the server
-will never know the actual value returned at Runtime. However we consider enforcing annotations a good-enough approach for early implementations.
+### How it works
 
-You can check the [class documentation](./src/mcp_server/__init__.py) for more information.
+`DataToolOutput` is defined as:
+
+```python
+DataToolOutput = Annotated[CallToolResult, ValidationModel]
+```
+
+This combines the MCP SDK's `CallToolResult` return type with a `ValidationModel` (a Pydantic model) using Python's `Annotated` generic. The MCP SDK uses this pattern to enable [structured output](https://github.com/modelcontextprotocol/python-sdk?tab=readme-ov-file#structured-output) — validating that the `structuredContent` field conforms to the `ValidationModel` schema.
+
+The `ToolRegistry` enforces this annotation at startup time by inspecting each tool function's return type. Tools that do not declare `-> DataToolOutput` are **skipped** with a warning and will not be registered. Because Python is dynamically typed, the server cannot validate actual runtime return values, but enforcing annotations is a good-enough approach for early implementations.
+
+### CallToolResult: `content` and `structuredContent`
+
+Every tool must return a `CallToolResult` with two fields:
+
+- **`content`** (`list[TextContent | ImageContent | ...]`): The human-readable output that the LLM uses to understand and respond to the user. This is always required.
+- **`structuredContent`** (`dict conforming to ValidationModel`): A machine-parseable JSON payload that the chat interface uses to render structured elements like tables, charts, and source links. This is optional but recommended.
+
+Both fields serve different consumers: `content` is for the **LLM**, while `structuredContent` is for the **UI**.
+
+Providing both gives flexibility by ensuring the AI can answer the question and the developers can render it in a structured way.
+
+For more information on `content`/`structuredContent`:
+
+- [How Langchain uses this fields](https://forum.langchain.com/t/why-can-the-model-see-the-structured-content-returned-by-the-mcp-tool/3076).
+- [User Guidance community discussion](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1624)
+
+### ValidationModel fields
+
+The `structuredContent` dict must conform to the following schema:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `sources` | `list` | *required* | Information pointing to the original source of the data. |
+| `table` | `list` | `[]` | Two-dimensional list (list of rows) representing tabular data. Each row should be a list of cell values. |
+| `charts` | `list` | `[]` | *(in development)* Dictionaries containing data and configuration for rendering Chart.js charts. |
+| `force` | `str` | `""` | Plain text message that bypasses LLM processing and is printed exactly as provided. |
+
+### Examples
+
+**Minimal — text with a data source:**
+
+```python
+from mcp.types import CallToolResult, TextContent
+from mcp_server import DataToolOutput
+
+@registry.tool()
+def get_gdp() -> DataToolOutput:
+    """Return the latest GDP value."""
+    return CallToolResult(
+        content=[TextContent(type="text", text="The GDP for 2024 is $1.2 trillion.")],
+        structuredContent={"sources": ["https://example.org/gdp-data"]},
+    )
+```
+
+**Table data — returning tabular results:**
+
+```python
+from mcp.types import CallToolResult, TextContent
+from mcp_server import DataToolOutput
+
+@registry.tool()
+def list_cities() -> DataToolOutput:
+    """Return the top 3 cities by population."""
+    return CallToolResult(
+        content=[TextContent(type="text", text="Found 3 cities sorted by population.")],
+        structuredContent={
+            "sources": ["https://example.org/cities-data"],
+            "table": [
+                ["City", "Population"],
+                ["Tokyo", "37400068"],
+                ["Delhi", "30290936"],
+                ["Shanghai", "27058479"],
+            ],
+        },
+    )
+```
+
+You can check the [source code](./src/mcp_server/__init__.py) for more information.
 

--- a/README.md
+++ b/README.md
@@ -47,14 +47,21 @@ The Plugin needs to:
 uv init --package mcp-ckan-exampleplugin
 ```
 
-2. Define a `register_tools(mcp)` function that register tools in a MCP Server:
+2. Define a `register_tools(mcp)` function that register tools in a MCP Server registry:
 
 ```python
-def register_tools(mcp):
-    @mcp.tool()
-    def greetings_from_examplepythontools():
-        return "Hello from mcp_ckan_examplepythontools!"
+from mcp_server import ToolOutput
+
+def register_tools(registry):
+    @registry.tool()
+    def greetings_from_examplepythontools() -> ToolOutput:
+        return ToolOutput(
+            source="https://example.org",
+            content="Hello from mcp_ckan_examplepythontools!"
+        )
 ```
+
+**Note:** This MCP server enforces [structured output](https://github.com/modelcontextprotocol/python-sdk?tab=readme-ov-file#structured-output) and validates that the type returned is `ToolOutput`. If the function does not have the type annotation `-> ToolOutput` it will not be registered.
 
 3. Register a new `mcp_ckan` entrypoint in the `pyproject.toml` file that calls the `register_tools` function.
 
@@ -62,6 +69,15 @@ def register_tools(mcp):
 [project.entry-points."mcp_ckan"]
 mcp-ckan-examplepythontools = "mcp_ckan_examplepythontools:register_tools"
 ```
+
+## ToolOutput
+
+This MCP Server has a light-validation of the return type of the tools it registers. The goal of `ToolOutput` is to have a standarized communication between plugins and server.
+
+Because Python is a dynamically typed language we can only validate (at startup time) function signatures. This will not ensure that the actual value returned at Runtime will
+be a ToolOutput serialized object but it is a good-enough approach for early implementations.
+
+You can check the [class documentation](./src/mcp_server/__init__.py) for more information.
 
 ## Server Settings
 

--- a/README.md
+++ b/README.md
@@ -22,63 +22,6 @@ Run the server:
 uv run mcp-ckan
 ```
 
-## Fetching Remote Tools
-
-To register remote tools just install a Python package that can register MCP tools for your particular datasets.
-You can see an example at [https://github.com/okfn/mcp-ckan-examplepythontools](https://github.com/okfn/mcp-ckan-examplepythontools)
-
-In a nutshell, you can extend by installing python plugins:
-
-```bash
-uv pip install "git+https://github.com/okfn/mcp-ckan"
-uv pip install "git+https://github.com/okfn/mcp-ckan-examplepythontools"
-uv run mcp-ckan
-```
-
-The MCP server is configured to load the tools at startup time by iterating throug all the installed python packages looking for `mcp_ckan` entrypoints.
-
-### Developing a new MCP CKAN plugin
-
-The Plugin needs to:
-
-1. Be a proper python pip-installable package:
-
-```bash
-uv init --package mcp-ckan-exampleplugin
-```
-
-2. Define a `register_tools(mcp)` function that register tools in a MCP Server registry:
-
-```python
-from mcp_server import ToolOutput
-
-def register_tools(registry):
-    @registry.tool()
-    def greetings_from_examplepythontools() -> ToolOutput:
-        return ToolOutput(
-            source="https://example.org",
-            content="Hello from mcp_ckan_examplepythontools!"
-        )
-```
-
-**Note:** This MCP server enforces [structured output](https://github.com/modelcontextprotocol/python-sdk?tab=readme-ov-file#structured-output) and validates that the type returned is `ToolOutput`. If the function does not have the type annotation `-> ToolOutput` it will not be registered.
-
-3. Register a new `mcp_ckan` entrypoint in the `pyproject.toml` file that calls the `register_tools` function.
-
-```toml
-[project.entry-points."mcp_ckan"]
-mcp-ckan-examplepythontools = "mcp_ckan_examplepythontools:register_tools"
-```
-
-## ToolOutput
-
-This MCP Server has a light-validation of the return type of the tools it registers. The goal of `ToolOutput` is to have a standarized communication between plugins and server.
-
-Because Python is a dynamically typed language we can only validate (at startup time) function signatures. This will not ensure that the actual value returned at Runtime will
-be a ToolOutput serialized object but it is a good-enough approach for early implementations.
-
-You can check the [class documentation](./src/mcp_server/__init__.py) for more information.
-
 ## Server Settings
 
 This (and other settings) can be configured via the `settings.py` file (or environment variables if defined).
@@ -112,4 +55,85 @@ This tool allows you to test tools locally without any AI model.
 ```bash
 npx @modelcontextprotocol/inspector uv run mcp-ckan
 ```
+
+## Fetching Remote Tools
+
+To register remote tools just install a Python package that can register MCP tools for your particular datasets.
+You can see an example at [https://github.com/okfn/mcp-ckan-examplepythontools](https://github.com/okfn/mcp-ckan-examplepythontools)
+
+In a nutshell, you can extend by installing python plugins:
+
+```bash
+uv pip install "git+https://github.com/okfn/mcp-ckan"
+uv pip install "git+https://github.com/okfn/mcp-ckan-examplepythontools"
+uv run mcp-ckan
+```
+
+The MCP server is configured to load the tools at startup time by iterating throug all the installed python packages looking for `mcp_ckan` entrypoints.
+
+# Tutorial: Developing a new MCP CKAN plugin
+
+## Creating a new plugin
+
+1. Create a new pip-installable package:
+
+```bash
+uv init --package mcp-ckan-exampleplugin
+cd mcp-ckan-exampleplugin
+```
+
+2. Install the mcp-ckan dependency:
+
+```bash
+uv add https://github.com/okfn/mcp-ckan.git
+```
+
+3. Define a `register_tools(mcp)` function that register tools in a MCP Server registry:
+
+**Note:** This MCP server enforces [structured output](https://github.com/modelcontextprotocol/python-sdk?tab=readme-ov-file#structured-output)
+so the `DataToolOutput` annotation and the `CallToolResult` return value are mandatory. If the function does not have the type annotation `-> DataToolOutput`
+it will not be registered in the MCP server.
+
+```python
+from mcp.types import CallToolResult, TextContent
+from mcp_server import DataToolOutput
+
+def register_tools(registry):
+
+    @registry.tool()
+    def greetings_from_examplepythontools() -> DataToolOutput:
+        """Return a greetings message to the user."""
+        source = "https://example.org/link/to/data"
+        return CallToolResult(
+            content=[TextContent(type="text", text="Hello from an Example Plugin!")],
+            structuredContent={"sources": [source]},
+        )
+```
+
+4. Register a new `mcp_ckan` entrypoint in the `pyproject.toml` file that calls the newly created `register_tools` function.
+
+```toml
+[project.entry-points."mcp_ckan"]
+mcp-ckan-examplepythontools = "mcp_ckan_examplepythontools:register_tools"
+```
+
+5. Run the mcp-ckan server (inside the newly created package folder)
+```
+MCP_TRANSPORT=http uv run mcp-ckan
+```
+
+6. Run MCP Inspector to test the tool
+```
+npx @modelcontextprotocol/inspector
+```
+
+## DataToolOutput
+
+This MCP Server has a `ValidationModel` for the return type of the tools it will register. The goal of the `ValidationModel` and the `DataToolOutput` annotation
+is to have a standarized communication between plugins and server. The schema is still on development so changes are expected.
+
+Because Python is a dynamically typed language we can only validate function signatures at startup time. This means the server
+will never know the actual value returned at Runtime. However we consider enforcing annotations a good-enough approach for early implementations.
+
+You can check the [class documentation](./src/mcp_server/__init__.py) for more information.
 

--- a/src/mcp_server/__init__.py
+++ b/src/mcp_server/__init__.py
@@ -19,7 +19,7 @@ class ToolOutput(BaseModel):
         default="",
         description="Direct response for the LLM to consume. Supports plain text, Markdown, or other text-based formats."
     )
-    structured_content: dict = Field(
+    structuredContent: dict = Field(
         default={},
         description="JSON-serializable dictionary with arbitrary keys. Provides structured data for the LLM when plain text is insufficient."
     )

--- a/src/mcp_server/__init__.py
+++ b/src/mcp_server/__init__.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel, Field
+
+
+class ToolOutput(BaseModel):
+    """Class for MCP Tools structured output."""
+    source: str = Field(
+        description="Complete URL pointing to the original source of the data."
+    )
+    content: str = Field(
+        default="",
+        description="Direct response for the LLM to consume. Supports plain text, Markdown, or other text-based formats."
+    )
+    structured_content: dict = Field(
+        default={},
+        description="JSON-serializable dictionary with arbitrary keys. Provides structured data for the LLM when plain text is insufficient."
+    )
+    table: list = Field(
+        default=[],
+        description="Two-dimensional list (list of rows) representing tabular data, e.g., from CSV or TSV sources. Each row should be a list of cell values."
+    )
+    chart: dict = Field(
+        default={},
+        description="Dictionary containing data and configuration for rendering a Chart.js chart in the chat interface. Structure must follow Chart.js expected format."
+    )
+    force: str = Field(
+        default="",
+        description="Plain text message that bypasses LLM processing. Printed exactly as provided in the user interface – used for debugging or developer-to-user notifications."
+    )

--- a/src/mcp_server/__init__.py
+++ b/src/mcp_server/__init__.py
@@ -11,7 +11,7 @@ class ValidationModel(BaseModel):
     don't comply are skipped with a warning.
 
     The serialized dict (via ``model_dump()``) is returned to the MCP client
-    in the `structuredOutput` field of the response.
+    in the `structuredContent` field of the response.
     """
     sources: list = Field(
         description="Information pointing to the original source of the data."

--- a/src/mcp_server/__init__.py
+++ b/src/mcp_server/__init__.py
@@ -2,7 +2,17 @@ from pydantic import BaseModel, Field
 
 
 class ToolOutput(BaseModel):
-    """Class for MCP Tools structured output."""
+    """Structured output for all MCP tools in this server.
+
+    Every tool registered through the ToolRegistry must return an instance of this
+    class. The registry enforces this at startup by inspecting the function's return
+    type annotation — tools without ``-> ToolOutput`` will be rejected with a
+    ``TypeError`` before the server starts.
+
+    The serialized dict (via ``model_dump()``) is returned to the MCP client,
+    giving consumers direct access to all fields regardless of which ones a
+    particular tool populates.
+    """
     source: str = Field(
         description="Complete URL pointing to the original source of the data."
     )

--- a/src/mcp_server/__init__.py
+++ b/src/mcp_server/__init__.py
@@ -4,10 +4,9 @@ from pydantic import BaseModel, Field
 class ToolOutput(BaseModel):
     """Structured output for all MCP tools in this server.
 
-    Every tool registered through the ToolRegistry must return an instance of this
-    class. The registry enforces this at startup by inspecting the function's return
-    type annotation — tools without ``-> ToolOutput`` will be rejected with a
-    ``TypeError`` before the server starts.
+    Every tool registered through the ToolRegistry must declare ``-> ToolOutput``
+    in its return annotation.  The registry checks this at startup; tools that
+    don't comply are skipped with a warning rather than causing a crash.
 
     The serialized dict (via ``model_dump()``) is returned to the MCP client,
     giving consumers direct access to all fields regardless of which ones a

--- a/src/mcp_server/__init__.py
+++ b/src/mcp_server/__init__.py
@@ -6,7 +6,7 @@ class ToolOutput(BaseModel):
 
     Every tool registered through the ToolRegistry must declare ``-> ToolOutput``
     in its return annotation.  The registry checks this at startup; tools that
-    don't comply are skipped with a warning rather than causing a crash.
+    don't comply are skipped with a warning.
 
     The serialized dict (via ``model_dump()``) is returned to the MCP client,
     giving consumers direct access to all fields regardless of which ones a

--- a/src/mcp_server/__init__.py
+++ b/src/mcp_server/__init__.py
@@ -1,37 +1,33 @@
+from typing import Annotated
+from mcp.types import CallToolResult
 from pydantic import BaseModel, Field
 
 
-class ToolOutput(BaseModel):
-    """Structured output for all MCP tools in this server.
+class ValidationModel(BaseModel):
+    """Schema for all Structured Outputs of the MCP server.
 
-    Every tool registered through the ToolRegistry must declare ``-> ToolOutput``
+    Every tool registered through the ToolRegistry must declare ``-> DataToolOutput``
     in its return annotation.  The registry checks this at startup; tools that
     don't comply are skipped with a warning.
 
-    The serialized dict (via ``model_dump()``) is returned to the MCP client,
-    giving consumers direct access to all fields regardless of which ones a
-    particular tool populates.
+    The serialized dict (via ``model_dump()``) is returned to the MCP client
+    in the `structuredOutput` field of the response.
     """
-    source: str = Field(
-        description="Complete URL pointing to the original source of the data."
-    )
-    content: str = Field(
-        default="",
-        description="Direct response for the LLM to consume. Supports plain text, Markdown, or other text-based formats."
-    )
-    structuredContent: dict = Field(
-        default={},
-        description="JSON-serializable dictionary with arbitrary keys. Provides structured data for the LLM when plain text is insufficient."
+    sources: list = Field(
+        description="Information pointing to the original source of the data."
     )
     table: list = Field(
         default=[],
         description="Two-dimensional list (list of rows) representing tabular data, e.g., from CSV or TSV sources. Each row should be a list of cell values."
     )
-    chart: dict = Field(
-        default={},
-        description="Dictionary containing data and configuration for rendering a Chart.js chart in the chat interface. Structure must follow Chart.js expected format."
+    charts: list = Field(
+        default=[],
+        description="List of dictionaries containing data and configuration for rendering a Chart.js chart in the chat interface."
     )
     force: str = Field(
         default="",
-        description="Plain text message that bypasses LLM processing. Printed exactly as provided in the user interface – used for debugging or developer-to-user notifications."
+        description="Plain text message that bypasses LLM processing and should be printed exactly as provided in the user interface."
     )
+
+
+DataToolOutput = Annotated[CallToolResult, ValidationModel]

--- a/src/mcp_server/registry.py
+++ b/src/mcp_server/registry.py
@@ -6,10 +6,29 @@ from mcp_server import ToolOutput
 
 
 class ToolRegistry:
+    """Controls tool registration and enforces the ToolOutput contract.
+
+    Wraps a FastMCP instance and intercepts every ``tool()`` call to verify that
+    the function declares ``-> ToolOutput`` in its return annotation.  Validation
+    happens at registration time (server startup), not at call time, so invalid
+    tools fail fast before any client request is served.
+
+    Plugins and engines must use this registry instead of calling ``mcp.tool()``
+    directly.  The ``tool()`` method returns the same decorator API as FastMCP
+    so existing patterns (``@registry.tool()`` and ``registry.tool()(fn)``) work
+    unchanged.
+    """
+
     def __init__(self, mcp: FastMCP):
         self._mcp = mcp
 
     def tool(self):
+        """Decorator that registers a function with FastMCP after validating its
+        return type annotation.
+
+        Raises:
+            TypeError: If the function's return annotation is not ``ToolOutput``.
+        """
         def decorator(fn):
             sig = inspect.signature(fn)
             return_annotation = sig.return_annotation

--- a/src/mcp_server/registry.py
+++ b/src/mcp_server/registry.py
@@ -1,8 +1,11 @@
 import inspect
+import logging
 
 from mcp.server.fastmcp import FastMCP
 
 from mcp_server import ToolOutput
+
+log = logging.getLogger(__name__)
 
 
 class ToolRegistry:
@@ -10,8 +13,11 @@ class ToolRegistry:
 
     Wraps a FastMCP instance and intercepts every ``tool()`` call to verify that
     the function declares ``-> ToolOutput`` in its return annotation.  Validation
-    happens at registration time (server startup), not at call time, so invalid
-    tools fail fast before any client request is served.
+    happens at registration time (server startup), not at call time.
+
+    Tools that do not declare the correct return annotation are **not registered**
+    and a warning is logged instead.  This allows the server to start and serve
+    only its valid tools, rather than crashing on the first bad plugin.
 
     Plugins and engines must use this registry instead of calling ``mcp.tool()``
     directly.  The ``tool()`` method returns the same decorator API as FastMCP
@@ -26,8 +32,8 @@ class ToolRegistry:
         """Decorator that registers a function with FastMCP after validating its
         return type annotation.
 
-        Raises:
-            TypeError: If the function's return annotation is not ``ToolOutput``.
+        If the return annotation is not ``ToolOutput``, logs a warning and returns
+        the original function **without** registering it with FastMCP.
         """
         def decorator(fn):
             sig = inspect.signature(fn)
@@ -38,8 +44,11 @@ class ToolRegistry:
                     if return_annotation is inspect.Parameter.empty
                     else return_annotation.__name__
                 )
-                raise TypeError(
-                    f"{fn.__name__}: return annotation must be ToolOutput, got {got}"
+                log.warning(
+                    "Skipping tool '%s': return annotation must be ToolOutput, got %s",
+                    fn.__name__,
+                    got,
                 )
+                return fn
             return self._mcp.tool()(fn)
         return decorator

--- a/src/mcp_server/registry.py
+++ b/src/mcp_server/registry.py
@@ -3,7 +3,7 @@ import logging
 
 from mcp.server.fastmcp import FastMCP
 
-from mcp_server import ToolOutput
+from mcp_server import DataToolOutput
 
 log = logging.getLogger(__name__)
 
@@ -12,7 +12,7 @@ class ToolRegistry:
     """Controls tool registration and enforces the ToolOutput contract.
 
     Wraps a FastMCP instance and intercepts every ``tool()`` call to verify that
-    the function declares ``-> ToolOutput`` in its return annotation.  Validation
+    the function declares ``-> DataToolOutput`` in its return annotation.  Validation
     happens at registration time (server startup).
 
     Tools that do not declare the correct return annotation are **not registered**
@@ -37,14 +37,14 @@ class ToolRegistry:
         def decorator(fn):
             sig = inspect.signature(fn)
             return_annotation = sig.return_annotation
-            if return_annotation is inspect.Parameter.empty or return_annotation is not ToolOutput:
+            if return_annotation is inspect.Parameter.empty or return_annotation is not DataToolOutput:
                 got = (
                     "none"
                     if return_annotation is inspect.Parameter.empty
                     else return_annotation.__name__
                 )
                 log.warning(
-                    "Skipping tool '%s': return annotation must be ToolOutput, got %s",
+                    "Skipping tool '%s': return annotation must be DataToolOutput, got %s",
                     fn.__name__,
                     got,
                 )

--- a/src/mcp_server/registry.py
+++ b/src/mcp_server/registry.py
@@ -1,0 +1,26 @@
+import inspect
+
+from mcp.server.fastmcp import FastMCP
+
+from mcp_server import ToolOutput
+
+
+class ToolRegistry:
+    def __init__(self, mcp: FastMCP):
+        self._mcp = mcp
+
+    def tool(self):
+        def decorator(fn):
+            sig = inspect.signature(fn)
+            return_annotation = sig.return_annotation
+            if return_annotation is inspect.Parameter.empty or return_annotation is not ToolOutput:
+                got = (
+                    "none"
+                    if return_annotation is inspect.Parameter.empty
+                    else return_annotation.__name__
+                )
+                raise TypeError(
+                    f"{fn.__name__}: return annotation must be ToolOutput, got {got}"
+                )
+            return self._mcp.tool()(fn)
+        return decorator

--- a/src/mcp_server/registry.py
+++ b/src/mcp_server/registry.py
@@ -13,16 +13,15 @@ class ToolRegistry:
 
     Wraps a FastMCP instance and intercepts every ``tool()`` call to verify that
     the function declares ``-> ToolOutput`` in its return annotation.  Validation
-    happens at registration time (server startup), not at call time.
+    happens at registration time (server startup).
 
     Tools that do not declare the correct return annotation are **not registered**
     and a warning is logged instead.  This allows the server to start and serve
-    only its valid tools, rather than crashing on the first bad plugin.
+    only its valid tools.
 
     Plugins and engines must use this registry instead of calling ``mcp.tool()``
-    directly.  The ``tool()`` method returns the same decorator API as FastMCP
-    so existing patterns (``@registry.tool()`` and ``registry.tool()(fn)``) work
-    unchanged.
+    directly.  The ``tool()`` method returns the same decorator API so existing
+    patterns (``@registry.tool()`` and ``registry.tool()(fn)``) work unchanged.
     """
 
     def __init__(self, mcp: FastMCP):

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -2,7 +2,7 @@
 MCP Server with dynamic tool loading
 
 This server automatically discovers and loads tools from installed python packages.
-Each package should have an `mcp_ckan` entrypoint with a register_tools(mcp) function.
+Each package should have an `mcp_ckan` entrypoint with a register_tools(registry) function.
 """
 import importlib
 import logging
@@ -11,21 +11,22 @@ import pkgutil
 from mcp.server.fastmcp import FastMCP
 
 from mcp_server.engines import load_dataset
+from mcp_server.registry import ToolRegistry
 from mcp_server.settings import MCP_TRANSPORT, MCP_HOST, MCP_PORT
 
 log = logging.getLogger(__name__)
 
 
-def load_python_plugins(mcp):
+def load_python_plugins(registry):
     """Load Python tools defined in plugins."""
     for entry_point in importlib.metadata.entry_points():
         if entry_point.group == "mcp_ckan":
             log.info(f"[{entry_point.module}] - python tools.")
             register_tools = entry_point.load()
-            register_tools(mcp)
+            register_tools(registry)
 
 
-def load_yaml_plugins(mcp):
+def load_yaml_plugins(registry):
     """Load YAML tools defined in plugins.
 
     The YAML tools are based on our engines. It will use a name-convention look for plugin
@@ -38,14 +39,15 @@ def load_yaml_plugins(mcp):
         resources = importlib.resources.files(plugin)
         for resource in resources.rglob('*.yaml'):
             log.info(f"[{plugin}] - {resource.name}")
-            load_dataset(mcp, resource)
+            load_dataset(registry, resource)
 
 
 def create_mcp_server(host, port):
     """Create MCP server with settings from environment variables"""
     mcp = FastMCP("Demo", host=host, port=port, streamable_http_path="/")
-    load_python_plugins(mcp)
-    load_yaml_plugins(mcp)
+    registry = ToolRegistry(mcp)
+    load_python_plugins(registry)
+    load_yaml_plugins(registry)
     return mcp
 
 


### PR DESCRIPTION
Some early implementations are guiding us to use [Structured Outputs](https://github.com/modelcontextprotocol/python-sdk?tab=readme-ov-file#structured-output) as discussed in #32. 

Example PR implementing this changes in the example extension:  https://github.com/okfn/mcp-ckan-examplepythontools/pull/1

Example PR implementing this changes in `mcp-datos-uruguay`: https://github.com/okfn/mcp-datos-uruguay/pull/4

Example PR implementing this changes in `mcp-chat-gateway`: https://github.com/okfn/mcp-chat-gateway/pull/12

### Usage

Ideally, all plugins should be forced to return this object. This will create a standard response that applications and chat interfaces can parse and work with.

This can be use for:
 - Force plugins to always return the source of the data (for traceability)
 - Have a standard way to return data for visualizations
 - Validate, at tool register time, that plugins follow best-practices.
