### PR TITLE
Namespace names for tools so we avoid collision

### DIFF
--- a/src/mcp_server/registry.py
+++ b/src/mcp_server/registry.py
@@ -22,10 +22,21 @@ class ToolRegistry:
     Plugins and engines must use this registry instead of calling ``mcp.tool()``
     directly.  The ``tool()`` method returns the same decorator API so existing
     patterns (``@registry.tool()`` and ``registry.tool()(fn)``) work unchanged.
+    Use ``for_plugin()`` so every tool that plugin registers is automatically namespaced.
     """
 
-    def __init__(self, mcp: FastMCP):
+    def __init__(self, mcp: FastMCP, namespace: str | None = None):
         self._mcp = mcp
+        self._namespace = namespace
+
+    def for_plugin(self, package_name: str) -> "ToolRegistry":
+        """Return a sub-registry that namespaces tools under the plugin package.
+
+        The returned registry shares the same FastMCP instance, so all tools
+        end up on the same server, but their names are prefixed with the
+        namespace derived from ``package_name``.
+        """
+        return ToolRegistry(self._mcp, namespace=package_name)
 
     def tool(self):
         """Decorator that registers a function with FastMCP after validating its
@@ -33,6 +44,10 @@ class ToolRegistry:
 
         If the return annotation is not ``ToolOutput``, logs a warning and returns
         the original function **without** registering it with FastMCP.
+
+        When this registry was obtained via ``for_plugin``, the
+        function's ``__name__`` is prefixed with the plugin namespace before
+        being handed to FastMCP, so we avoind name collisions.
         """
         def decorator(fn):
             sig = inspect.signature(fn)
@@ -49,5 +64,10 @@ class ToolRegistry:
                     got,
                 )
                 return fn
+            # If defined, apply the plugin namespace
+            if self._namespace and not fn.__name__.startswith(self._namespace + "_"):
+                fn.__name__ = f"{self._namespace}_{fn.__name__}"
+
+            log.info(f" - Registered: [{fn.__name__}]")
             return self._mcp.tool()(fn)
         return decorator

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -18,12 +18,15 @@ log = logging.getLogger(__name__)
 
 
 def load_python_plugins(registry):
-    """Load Python tools defined in plugins."""
+    """Load Python tools defined in plugins.
+    Each plugin defines a namespaced sub-registry so we avoid name colition
+    """
     for entry_point in importlib.metadata.entry_points():
         if entry_point.group == "mcp_ckan":
             log.info(f"[{entry_point.module}] - python tools.")
             register_tools = entry_point.load()
-            register_tools(registry)
+            plugin_registry = registry.for_plugin(entry_point.module)
+            register_tools(plugin_registry)
 
 
 def load_yaml_plugins(registry):
@@ -33,13 +36,16 @@ def load_yaml_plugins(registry):
     packages (like Flask).
 
     https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-naming-convention
+    Each plugin's YAMLs are loaded against a namespaced sub-registry,
+    so YAML-declared tool names get the same prefix as Python ones.
     """
     discovered_plugins = [name for _, name, _ in pkgutil.iter_modules() if name.startswith('mcp_ckan_')]
     for plugin in discovered_plugins:
         resources = importlib.resources.files(plugin)
+        plugin_registry = registry.for_plugin(plugin)
         for resource in resources.rglob('*.yaml'):
             log.info(f"[{plugin}] - {resource.name}")
-            load_dataset(registry, resource)
+            load_dataset(plugin_registry, resource)
 
 
 def create_mcp_server(host, port):

--- a/tests/test_plugin_loading.py
+++ b/tests/test_plugin_loading.py
@@ -32,6 +32,10 @@ class TestPythonPlugins:
 
             load_python_plugins(mcp_mock)
 
-            mock_plugin_register_tools.assert_called_once_with(mcp_mock)
+            # The plugin must be handed a namespaced sub-registry, not the root
+            # registry, so its tool names get prefixed by package and cannot
+            # collide with other plugins.
+            mcp_mock.for_plugin.assert_called_once_with("mcp_ckan_test")
+            mock_plugin_register_tools.assert_called_once_with(mcp_mock.for_plugin.return_value)
             mock_non_mcp_ckan_register_tools.assert_not_called()
             mock_non_group_ckan_register_tools.assert_not_called()


### PR DESCRIPTION
Fixes #36 

<img width="2989" height="1457" alt="image" src="https://github.com/user-attachments/assets/3569538f-f53e-44b9-b539-5ef19744b9f2" />

This fixes the name collision but no fix for the meaning answer collision. Probably "no political question will be a duplicated idea in several repos.