### PR TITLE
Allow plugins to define descriptions and questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,31 @@ npx @modelcontextprotocol/inspector
 
 7. Navigate to the MCP Inspector webpage and connect to `http://127.0.0.1:8063` (no `/mcp`) using `Streamable HTTP` transport type
 
+## Self-describing your plugin
+
+Clients that browse the tool catalog (the chat gateway, MCP Inspector, etc.) can render a richer landing card when a plugin advertises its own description and sample questions. Use `registry.set_plugin_info()` from `register_tools()` **before** declaring any `@registry.tool()`, so every tool's `_meta.plugin_metadata` picks up the values:
+
+```python
+def register_tools(registry):
+
+    registry.set_plugin_info(
+        description=(
+            "Tools over Example Org's open data. "
+            "Public procurement, budgets, and beneficiary lists."
+        ),
+        sample_questions=[
+            "Which companies sell medicine to the government?",
+            "Top 10 recipients of parliamentary amendments",
+        ],
+    )
+
+    @registry.tool()
+    def my_first_tool() -> DataToolOutput:
+        ...
+```
+
+Both fields are optional. `description` is shown as the plugin card subtitle; `sample_questions` become clickable chips that pre-fill the chat input. Repo URLs (Homepage, Issues, Repository, …) are read separately from your `[project.urls]` table in `pyproject.toml` — no need to repeat them here.
+
 ## Tool return values
 
 Using the `python-sdk` cannonical way of building results (this is, the `CallToolResult` object) can get quite verbose quite fast. For

--- a/src/mcp_server/registry.py
+++ b/src/mcp_server/registry.py
@@ -45,6 +45,24 @@ class ToolRegistry:
             plugin_metadata=get_repo_metadata(package_name),
         )
 
+    def set_plugin_info(self, description: str | None = None, sample_questions: list[str] | None = None) -> None:
+        """Self-describe the plugin so MCP clients can render a richer catalog.
+
+        Plugins call this from ``register_tools()`` before declaring their tools.
+        The values are merged into ``_meta.plugin_metadata`` alongside the URLs
+        already read from ``[project.urls]`` — the server stays agnostic; only
+        the plugin knows what its description and sample questions are.
+
+        Call this BEFORE any ``@registry.tool()`` decorators so every tool's
+        meta payload picks up the new fields.
+        """
+        if self._plugin_metadata is None:
+            self._plugin_metadata = {}
+        if description is not None:
+            self._plugin_metadata["description"] = description
+        if sample_questions is not None:
+            self._plugin_metadata["sample_questions"] = list(sample_questions)
+
     def tool(self):
         """Decorator that registers a function with FastMCP after validating its
         return type annotation.


### PR DESCRIPTION
Related to https://github.com/okfn/mcp-chat-gateway/issues/18

Visible at:
 - https://github.com/okfn/mcp-chat-gateway/pull/19

Implemented at:
 - https://github.com/okfn/mcp-dados-brasil/pull/8
 - https://github.com/okfn/mcp-datos-uruguay/pull/8

We continue adding data to the `ToolRegistry._plugin_metadata` to include description and questions

Note: the _Ask OKFN_ title is a custom internal rebranding (now available)

<img width="3803" height="1531" alt="image" src="https://github.com/user-attachments/assets/209d5524-36fb-49cc-8593-ac29521d993c" />
