### PR TITLE
Make MCP Server CKAN agnostic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 **Note:** This project is currently in early research phase. Breaking changes are expected.
 
-MCP Server that allows admins to register custom tools, by installing python packages, to consistently and accurately answer user questions using data.
+An MCP server to build rich AI data applications with focus on traceability. This server allows admins to register custom tools, by installing
+python packages, to consistently and accurately answer user questions using data.
 
 ## Running locally
 
@@ -19,7 +20,7 @@ uv run pytest
 
 Run the server:
 ```bash
-uv run mcp-ckan
+uv run mcp-server
 ```
 
 ## Server Settings
@@ -39,7 +40,7 @@ Create the file `.vscode/mcp.json`:
 ```json
 {
   "servers": {
-    "mybcie-server": {
+    "my-server": {
       "url": "http://127.0.0.1:8063",
       "type": "http"
     }
@@ -53,39 +54,39 @@ Create the file `.vscode/mcp.json`:
 This tool allows you to test tools locally without any AI model.
 
 ```bash
-npx @modelcontextprotocol/inspector uv run mcp-ckan
+npx @modelcontextprotocol/inspector uv run mcp-server
 ```
 
 ## Fetching Remote Tools
 
 To register remote tools just install a Python package that can register MCP tools for your particular datasets.
-You can see an example at [https://github.com/okfn/mcp-ckan-examplepythontools](https://github.com/okfn/mcp-ckan-examplepythontools)
+You can see an example at [https://github.com/okfn/mcp-examplepythontools](https://github.com/okfn/mcp-examplepythontools)
 
 In a nutshell, you can extend by installing python plugins:
 
 ```bash
-uv pip install "git+https://github.com/okfn/mcp-ckan"
-uv pip install "git+https://github.com/okfn/mcp-ckan-examplepythontools"
-uv run mcp-ckan
+uv pip install "git+https://github.com/okfn/mcp-server"
+uv pip install "git+https://github.com/okfn/mcp-examplepythontools"
+uv run mcp-server
 ```
 
-The MCP server is configured to load the tools at startup time by iterating throug all the installed python packages looking for `mcp_ckan` entrypoints.
+The MCP server is configured to load the tools at startup time by iterating throug all the installed python packages looking for `mcp_server` entrypoints.
 
-# Tutorial: Developing a new MCP CKAN plugin
+# Tutorial: Developing a new MCP Server Plugin
 
 ## Creating a new plugin
 
 1. Create a new pip-installable package:
 
 ```bash
-uv init --package mcp-ckan-exampleplugin
-cd mcp-ckan-exampleplugin
+uv init --package mcp-exampleplugin
+cd mcp-exampleplugin
 ```
 
-2. Install the mcp-ckan dependency:
+2. Install the mcp-server dependency:
 
 ```bash
-uv add https://github.com/okfn/mcp-ckan.git
+uv add https://github.com/okfn/mcp-server.git
 ```
 
 3. Define a `register_tools(mcp)` function that register tools in a MCP Server registry:
@@ -110,16 +111,16 @@ def register_tools(registry):
         )
 ```
 
-4. Register a new `mcp_ckan` entrypoint in the `pyproject.toml` file that calls the newly created `register_tools` function.
+4. Register a new `mcp_server` entrypoint in the `pyproject.toml` file that calls the newly created `register_tools` function.
 
 ```toml
-[project.entry-points.mcp_ckan]
-mcp-ckan-examplepythontools = "mcp_ckan_examplepythontools:register_tools"
+[project.entry-points.mcp_server]
+mcp-examplepythontools = "mcp_examplepythontools:register_tools"
 ```
 
-5. Run the mcp-ckan server (inside the newly created package folder)
+5. Run the MCP server (inside the newly created package folder)
 ```
-MCP_TRANSPORT=http uv run mcp-ckan
+MCP_TRANSPORT=http uv run mcp-server
 ```
 
 6. Run MCP Inspector to test the tool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mcp-server"
 version = "0.0.1"
-description = "Simple MCP server test with remote tools support."
+description = "An MCP server to build rich data applications with focus on traceability."
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [project.scripts]
-mcp-ckan = "mcp_server.server:main"
+mcp-server = "mcp_server.server:main"
 
 [dependency-groups]
 dev = [

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -2,7 +2,7 @@
 MCP Server with dynamic tool loading
 
 This server automatically discovers and loads tools from installed python packages.
-Each package should have an `mcp_ckan` entrypoint with a register_tools(registry) function.
+Each package should have an `mcp_server` entrypoint with a register_tools(registry) function.
 """
 import importlib
 import logging
@@ -22,7 +22,7 @@ def load_python_plugins(registry):
     Each plugin defines a namespaced sub-registry so we avoid name colition
     """
     for entry_point in importlib.metadata.entry_points():
-        if entry_point.group == "mcp_ckan":
+        if entry_point.group == "mcp_server":
             log.info(f"[{entry_point.module}] - python tools.")
             register_tools = entry_point.load()
             plugin_registry = registry.for_plugin(entry_point.module)
@@ -38,7 +38,7 @@ def load_python_resources(registry):
     with no documents/PDFs to expose simply don't define the function.
     """
     for entry_point in importlib.metadata.entry_points():
-        if entry_point.group != "mcp_ckan":
+        if entry_point.group != "mcp_server":
             continue
         module = importlib.import_module(entry_point.module)
         register_resources = getattr(module, "register_resources", None)
@@ -59,7 +59,7 @@ def load_yaml_plugins(registry):
     Each plugin's YAMLs are loaded against a namespaced sub-registry,
     so YAML-declared tool names get the same prefix as Python ones.
     """
-    discovered_plugins = [name for _, name, _ in pkgutil.iter_modules() if name.startswith('mcp_ckan_')]
+    discovered_plugins = [name for _, name, _ in pkgutil.iter_modules() if name.startswith('mcp_server_')]
     for plugin in discovered_plugins:
         resources = importlib.resources.files(plugin)
         plugin_registry = registry.for_plugin(plugin)

--- a/tests/test_plugin_loading.py
+++ b/tests/test_plugin_loading.py
@@ -3,28 +3,28 @@ from mcp_server.server import load_python_plugins
 
 
 class TestPythonPlugins:
-    def test_loads_only_plugins_with_mcp_ckan_group_entrypoints(self):
+    def test_loads_only_plugins_with_mcp_server_group_entrypoints(self):
         mcp_mock = MagicMock()
 
-        # A plugin with "mcp_ckan" entry point that should be loaded
+        # A plugin with "mcp_server" entry point that should be loaded
         mock_plugin_register_tools = MagicMock()
         mock_plugin_entry_point = Mock()
-        mock_plugin_entry_point.module = "mcp_ckan_test"
-        mock_plugin_entry_point.group = "mcp_ckan"
+        mock_plugin_entry_point.module = "mcp_server_test"
+        mock_plugin_entry_point.group = "mcp_server"
         mock_plugin_entry_point.load.return_value = mock_plugin_register_tools
 
-        # A plugin without "mcp_ckan" entry point that shouldn't be loaded
-        mock_non_mcp_ckan_register_tools = MagicMock()
+        # A plugin without "mcp_server" entry point that shouldn't be loaded
+        mock_non_mcp_server_register_tools = MagicMock()
         mock_non_mcp_plugin_entry_point = Mock()
         mock_non_mcp_plugin_entry_point.module = "plugin2"
         mock_non_mcp_plugin_entry_point.group = "another_group"
-        mock_non_mcp_plugin_entry_point.load.return_value = mock_non_mcp_ckan_register_tools
+        mock_non_mcp_plugin_entry_point.load.return_value = mock_non_mcp_server_register_tools
 
         # A plugin without group that shouldn't be loaded
-        mock_non_group_ckan_register_tools = MagicMock()
+        mock_non_group_server_register_tools = MagicMock()
         mock_non_mcp_plugin_entry_point = Mock()
         mock_non_mcp_plugin_entry_point.module = "plugin3"
-        mock_non_mcp_plugin_entry_point.load.return_value = mock_non_group_ckan_register_tools
+        mock_non_mcp_plugin_entry_point.load.return_value = mock_non_group_server_register_tools
 
         with patch("mcp_server.server.importlib.metadata.entry_points") as mock_eps:
             # mock_eps is the list of entrypoints in the virtualenv.
@@ -35,7 +35,7 @@ class TestPythonPlugins:
             # The plugin must be handed a namespaced sub-registry, not the root
             # registry, so its tool names get prefixed by package and cannot
             # collide with other plugins.
-            mcp_mock.for_plugin.assert_called_once_with("mcp_ckan_test")
+            mcp_mock.for_plugin.assert_called_once_with("mcp_server_test")
             mock_plugin_register_tools.assert_called_once_with(mcp_mock.for_plugin.return_value)
-            mock_non_mcp_ckan_register_tools.assert_not_called()
-            mock_non_group_ckan_register_tools.assert_not_called()
+            mock_non_mcp_server_register_tools.assert_not_called()
+            mock_non_group_server_register_tools.assert_not_called()


### PR DESCRIPTION
This PR makes some breaking changes to make it agnostic to CKAN and avoid creating confusion with other specialized MCP Servers.

Main Breaking changes:
 - Plugin's entrypoint needs to be renamed from `mcp_ckan` to `mcp_server`.
 - Repository name has been renamed from `mcp-ckan` to `mcp-server`. (pip installs needs to point to the new URL)
 - Main command to run the server changed from `uv run mcp-ckan` to `uv run mcp-server`.
 - Plugins registering `yaml` tools needs to be renamed from `mcp_ckan_<name>` to `mcp_server_<name>`