### PR TITLE
Prepare instructions

### DIFF
--- a/src/mcp_server/__init__.py
+++ b/src/mcp_server/__init__.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 class ValidationModel(BaseModel):
     """Schema for all Structured Outputs of the MCP server.
 
-    Every tool registered through the ToolRegistry must declare ``-> DataToolOutput``
+    Every tool registered through a plugin's Plugin registry must declare ``-> DataToolOutput``
     in its return annotation.  The registry checks this at startup; tools that
     don't comply are skipped with a warning.
 

--- a/src/mcp_server/registry.py
+++ b/src/mcp_server/registry.py
@@ -16,9 +16,6 @@ class PluginsRegistry:
     per plugin to hand each a namespaced :class:`Plugin`. After every
     plugin has loaded, ``build_instructions()`` composes the server's MCP
     ``instructions`` field from each plugin's self-description.
-
-    This is the "app" in the Flask analogy; :class:`Plugin` is the
-    "blueprint" a plugin registers tools and resources on.
     """
 
     def __init__(self, mcp: FastMCP):

--- a/src/mcp_server/registry.py
+++ b/src/mcp_server/registry.py
@@ -91,10 +91,16 @@ class Plugin:
         """
         if description is not None:
             self._plugin_metadata["description"] = description
+        else:
+            log.warning(f"Plugin {self._namespace} did not provide a description")
         if sample_questions is not None:
             self._plugin_metadata["sample_questions"] = list(sample_questions)
+        else:
+            log.warning(f"Plugin {self._namespace} did not provide sample questions")
         if instructions is not None:
             self._plugin_metadata["instructions"] = instructions
+        else:
+            log.warning(f"Plugin {self._namespace} did not provide instructions")
 
     def tool(self):
         """Decorator that registers a function with FastMCP after validating its

--- a/src/mcp_server/registry.py
+++ b/src/mcp_server/registry.py
@@ -9,33 +9,33 @@ from mcp_server.repo import get_repo_metadata
 log = logging.getLogger(__name__)
 
 
-class PluginRegistry:
+class PluginsRegistry:
     """Root registry: owns the FastMCP server and the set of all plugins.
 
     ``server.py`` builds exactly one of these, then calls ``for_plugin()`` once
-    per plugin to hand each a namespaced :class:`ToolRegistry`. After every
+    per plugin to hand each a namespaced :class:`Plugin`. After every
     plugin has loaded, ``build_instructions()`` composes the server's MCP
     ``instructions`` field from each plugin's self-description.
 
-    This is the "app" in the Flask analogy; :class:`ToolRegistry` is the
+    This is the "app" in the Flask analogy; :class:`Plugin` is the
     "blueprint" a plugin registers tools and resources on.
     """
 
     def __init__(self, mcp: FastMCP):
         self._mcp = mcp
         # ``{namespace: metadata}``. Each value is the SAME dict object the
-        # plugin's ToolRegistry mutates via set_plugin_info(), so
+        # plugin's Plugin mutates via set_plugin_info(), so
         # build_instructions() reads every plugin's final self-description from
         # here without any extra plumbing.
         self._plugins: dict[str, dict] = {}
 
-    def for_plugin(self, package_name: str) -> "ToolRegistry":
-        """Return a per-plugin :class:`ToolRegistry` that namespaces everything
+    def for_plugin(self, package_name: str) -> "Plugin":
+        """Return a per-plugin :class:`Plugin` that namespaces everything
         it registers under ``package_name`` while sharing this FastMCP server.
 
         for_plugin() is called once per registration pass (python tools, python
         resources, yaml), so the SAME plugin can ask for a registry several
-        times. Reuse the metadata dict across calls: the ToolRegistry gets the
+        times. Reuse the metadata dict across calls: the Plugin gets the
         same object, so set_plugin_info() mutations survive and later passes
         don't clobber them with a fresh get_repo_metadata().
         """
@@ -43,11 +43,11 @@ class PluginRegistry:
         if metadata is None:
             metadata = get_repo_metadata(package_name) or {}
             self._plugins[package_name] = metadata
-        return ToolRegistry(self._mcp, namespace=package_name, plugin_metadata=metadata)
+        return Plugin(self._mcp, namespace=package_name, plugin_metadata=metadata)
 
     def build_instructions(self) -> str:
         """Compose the server's MCP ``instructions`` string from the metadata
-        each plugin self-declares via ``ToolRegistry.set_plugin_info``.
+        each plugin self-declares via ``Plugin.set_plugin_info``.
 
         ``instructions`` is a standard field of the MCP ``initialize`` result:
         a free-text hint the server hands clients describing how to use it.
@@ -93,11 +93,11 @@ class PluginRegistry:
         return preamble + "\n\n" + "\n\n".join(blocks)
 
 
-class ToolRegistry:
+class Plugin:
     """Per-plugin registry: namespaces one plugin's tools/resources and enforces
     the ToolOutput contract.
 
-    Obtained from :meth:`PluginRegistry.for_plugin`; this is the object a plugin
+    Obtained from :meth:`PluginsRegistry.for_plugin`; this is the object a plugin
     receives in ``register_tools(registry)`` / ``register_resources(registry)``.
 
     Intercepts every ``tool()`` call to verify that the function declares
@@ -129,7 +129,7 @@ class ToolRegistry:
         The values are merged into ``_meta.plugin_metadata`` alongside the URLs
         already read from ``[project.urls]`` — the server stays agnostic; only
         the plugin knows what its description and sample questions are. The same
-        metadata is what :meth:`PluginRegistry.build_instructions` composes into
+        metadata is what :meth:`PluginsRegistry.build_instructions` composes into
         the server's MCP ``instructions``.
 
         Call this BEFORE any ``@registry.tool()`` decorators so every tool's

--- a/src/mcp_server/registry.py
+++ b/src/mcp_server/registry.py
@@ -9,59 +9,138 @@ from mcp_server.repo import get_repo_metadata
 log = logging.getLogger(__name__)
 
 
-class ToolRegistry:
-    """Controls tool registration and enforces the ToolOutput contract.
+class PluginRegistry:
+    """Root registry: owns the FastMCP server and the set of all plugins.
 
-    Wraps a FastMCP instance and intercepts every ``tool()`` call to verify that
-    the function declares ``-> DataToolOutput`` in its return annotation.  Validation
-    happens at registration time (server startup).
+    ``server.py`` builds exactly one of these, then calls ``for_plugin()`` once
+    per plugin to hand each a namespaced :class:`ToolRegistry`. After every
+    plugin has loaded, ``build_instructions()`` composes the server's MCP
+    ``instructions`` field from each plugin's self-description.
 
-    Tools that do not declare the correct return annotation are **not registered**
-    and a warning is logged instead.  This allows the server to start and serve
-    only its valid tools.
-
-    Plugins and engines must use this registry instead of calling ``mcp.tool()``
-    directly.  The ``tool()`` method returns the same decorator API so existing
-    patterns (``@registry.tool()`` and ``registry.tool()(fn)``) work unchanged.
-    Use ``for_plugin()`` so every tool that plugin registers is automatically namespaced.
+    This is the "app" in the Flask analogy; :class:`ToolRegistry` is the
+    "blueprint" a plugin registers tools and resources on.
     """
 
-    def __init__(self, mcp: FastMCP, namespace: str | None = None, plugin_metadata: dict | None = None):
+    def __init__(self, mcp: FastMCP):
+        self._mcp = mcp
+        # ``{namespace: metadata}``. Each value is the SAME dict object the
+        # plugin's ToolRegistry mutates via set_plugin_info(), so
+        # build_instructions() reads every plugin's final self-description from
+        # here without any extra plumbing.
+        self._plugins: dict[str, dict] = {}
+
+    def for_plugin(self, package_name: str) -> "ToolRegistry":
+        """Return a per-plugin :class:`ToolRegistry` that namespaces everything
+        it registers under ``package_name`` while sharing this FastMCP server.
+
+        for_plugin() is called once per registration pass (python tools, python
+        resources, yaml), so the SAME plugin can ask for a registry several
+        times. Reuse the metadata dict across calls: the ToolRegistry gets the
+        same object, so set_plugin_info() mutations survive and later passes
+        don't clobber them with a fresh get_repo_metadata().
+        """
+        metadata = self._plugins.get(package_name)
+        if metadata is None:
+            metadata = get_repo_metadata(package_name) or {}
+            self._plugins[package_name] = metadata
+        return ToolRegistry(self._mcp, namespace=package_name, plugin_metadata=metadata)
+
+    def build_instructions(self) -> str:
+        """Compose the server's MCP ``instructions`` string from the metadata
+        each plugin self-declares via ``ToolRegistry.set_plugin_info``.
+
+        ``instructions`` is a standard field of the MCP ``initialize`` result:
+        a free-text hint the server hands clients describing how to use it.
+        The gateway injects it into the LLM system prompt. Because the string
+        is built from whatever plugins are installed, a deployment with only
+        one plugin yields instructions scoped to that single domain.
+
+        Spec: https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle
+        (see the ``instructions`` field of ``InitializeResult``).
+        """
+        blocks = []
+        for namespace, meta in self._plugins.items():
+            if not meta:
+                continue
+            lines = []
+            # The plugin's own persona/doctrine, injected verbatim and first so
+            # it frames everything below (scope, units caveats, off-topic rule).
+            instructions = meta.get("instructions")
+            if instructions:
+                lines.append(instructions.strip())
+            description = meta.get("description")
+            if description:
+                lines.append(description.strip())
+            questions = meta.get("sample_questions") or []
+            if questions:
+                lines.append("Example questions it can answer:")
+                lines.extend(f"- {q}" for q in questions)
+            if lines:
+                blocks.append("\n".join(lines))
+
+        if not blocks:
+            return ""
+
+        # Tool names are namespaced per plugin, so the fallback tool surfaces as
+        # ``<plugin>_no_tool_disponible``. Reference it by suffix, not exact name.
+        preamble = (
+            "You are a data assistant. Answer every question using at least "
+            "one of the available tools; never answer factual questions from "
+            "your own knowledge. If no tool fits, call the fallback tool whose "
+            "name ends in `no_tool_disponible` with a short reason. The "
+            "available tools cover these domains:"
+        )
+        return preamble + "\n\n" + "\n\n".join(blocks)
+
+
+class ToolRegistry:
+    """Per-plugin registry: namespaces one plugin's tools/resources and enforces
+    the ToolOutput contract.
+
+    Obtained from :meth:`PluginRegistry.for_plugin`; this is the object a plugin
+    receives in ``register_tools(registry)`` / ``register_resources(registry)``.
+
+    Intercepts every ``tool()`` call to verify that the function declares
+    ``-> DataToolOutput`` in its return annotation. Validation happens at
+    registration time (server startup). Tools that do not declare the correct
+    return annotation are **not registered** and a warning is logged instead, so
+    the server still starts and serves its valid tools.
+
+    Plugins and engines must use this registry instead of calling ``mcp.tool()``
+    directly. The ``tool()`` method returns the same decorator API so existing
+    patterns (``@registry.tool()`` and ``registry.tool()(fn)``) work unchanged;
+    every tool name is automatically prefixed with the plugin namespace.
+    """
+
+    def __init__(self, mcp: FastMCP, namespace: str, plugin_metadata: dict):
         self._mcp = mcp
         self._namespace = namespace
         self._plugin_metadata = plugin_metadata
 
-    def for_plugin(self, package_name: str) -> "ToolRegistry":
-        """Return a sub-registry that namespaces tools under the plugin package.
-
-        The returned registry shares the same FastMCP instance, so all tools
-        end up on the same server, but their names are prefixed with the
-        namespace derived from ``package_name``.
-        Allow using metadata from the remote repo
-        """
-        return ToolRegistry(
-            self._mcp,
-            namespace=package_name,
-            plugin_metadata=get_repo_metadata(package_name),
-        )
-
-    def set_plugin_info(self, description: str | None = None, sample_questions: list[str] | None = None) -> None:
+    def set_plugin_info(
+        self,
+        description: str | None = None,
+        sample_questions: list[str] | None = None,
+        instructions: str | None = None,
+    ) -> None:
         """Self-describe the plugin so MCP clients can render a richer catalog.
 
         Plugins call this from ``register_tools()`` before declaring their tools.
         The values are merged into ``_meta.plugin_metadata`` alongside the URLs
         already read from ``[project.urls]`` — the server stays agnostic; only
-        the plugin knows what its description and sample questions are.
+        the plugin knows what its description and sample questions are. The same
+        metadata is what :meth:`PluginRegistry.build_instructions` composes into
+        the server's MCP ``instructions``.
 
         Call this BEFORE any ``@registry.tool()`` decorators so every tool's
         meta payload picks up the new fields.
         """
-        if self._plugin_metadata is None:
-            self._plugin_metadata = {}
         if description is not None:
             self._plugin_metadata["description"] = description
         if sample_questions is not None:
             self._plugin_metadata["sample_questions"] = list(sample_questions)
+        if instructions is not None:
+            self._plugin_metadata["instructions"] = instructions
 
     def tool(self):
         """Decorator that registers a function with FastMCP after validating its
@@ -70,9 +149,8 @@ class ToolRegistry:
         If the return annotation is not ``ToolOutput``, logs a warning and returns
         the original function **without** registering it with FastMCP.
 
-        When this registry was obtained via ``for_plugin``, the
-        function's ``__name__`` is prefixed with the plugin namespace before
-        being handed to FastMCP, so we avoind name collisions.
+        The function's ``__name__`` is prefixed with the plugin namespace before
+        being handed to FastMCP, so we avoid name collisions.
         """
         def decorator(fn):
             sig = inspect.signature(fn)

--- a/src/mcp_server/registry.py
+++ b/src/mcp_server/registry.py
@@ -20,21 +20,11 @@ class PluginsRegistry:
 
     def __init__(self, mcp: FastMCP):
         self._mcp = mcp
-        # ``{namespace: metadata}``. Each value is the SAME dict object the
-        # plugin's Plugin mutates via set_plugin_info(), so
-        # build_instructions() reads every plugin's final self-description from
-        # here without any extra plumbing.
         self._plugins: dict[str, dict] = {}
 
     def for_plugin(self, package_name: str) -> "Plugin":
         """Return a per-plugin :class:`Plugin` that namespaces everything
         it registers under ``package_name`` while sharing this FastMCP server.
-
-        for_plugin() is called once per registration pass (python tools, python
-        resources, yaml), so the SAME plugin can ask for a registry several
-        times. Reuse the metadata dict across calls: the Plugin gets the
-        same object, so set_plugin_info() mutations survive and later passes
-        don't clobber them with a fresh get_repo_metadata().
         """
         metadata = self._plugins.get(package_name)
         if metadata is None:
@@ -45,15 +35,6 @@ class PluginsRegistry:
     def build_instructions(self) -> str:
         """Compose the server's MCP ``instructions`` string from the metadata
         each plugin self-declares via ``Plugin.set_plugin_info``.
-
-        ``instructions`` is a standard field of the MCP ``initialize`` result:
-        a free-text hint the server hands clients describing how to use it.
-        The gateway injects it into the LLM system prompt. Because the string
-        is built from whatever plugins are installed, a deployment with only
-        one plugin yields instructions scoped to that single domain.
-
-        Spec: https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle
-        (see the ``instructions`` field of ``InitializeResult``).
         """
         blocks = []
         for namespace, meta in self._plugins.items():
@@ -93,20 +74,6 @@ class PluginsRegistry:
 class Plugin:
     """Per-plugin registry: namespaces one plugin's tools/resources and enforces
     the ToolOutput contract.
-
-    Obtained from :meth:`PluginsRegistry.for_plugin`; this is the object a plugin
-    receives in ``register_tools(registry)`` / ``register_resources(registry)``.
-
-    Intercepts every ``tool()`` call to verify that the function declares
-    ``-> DataToolOutput`` in its return annotation. Validation happens at
-    registration time (server startup). Tools that do not declare the correct
-    return annotation are **not registered** and a warning is logged instead, so
-    the server still starts and serves its valid tools.
-
-    Plugins and engines must use this registry instead of calling ``mcp.tool()``
-    directly. The ``tool()`` method returns the same decorator API so existing
-    patterns (``@registry.tool()`` and ``registry.tool()(fn)``) work unchanged;
-    every tool name is automatically prefixed with the plugin namespace.
     """
 
     def __init__(self, mcp: FastMCP, namespace: str, plugin_metadata: dict):
@@ -121,16 +88,6 @@ class Plugin:
         instructions: str | None = None,
     ) -> None:
         """Self-describe the plugin so MCP clients can render a richer catalog.
-
-        Plugins call this from ``register_tools()`` before declaring their tools.
-        The values are merged into ``_meta.plugin_metadata`` alongside the URLs
-        already read from ``[project.urls]`` — the server stays agnostic; only
-        the plugin knows what its description and sample questions are. The same
-        metadata is what :meth:`PluginsRegistry.build_instructions` composes into
-        the server's MCP ``instructions``.
-
-        Call this BEFORE any ``@registry.tool()`` decorators so every tool's
-        meta payload picks up the new fields.
         """
         if description is not None:
             self._plugin_metadata["description"] = description

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -11,7 +11,7 @@ import pkgutil
 from mcp.server.fastmcp import FastMCP
 
 from mcp_server.engines import load_dataset
-from mcp_server.registry import ToolRegistry
+from mcp_server.registry import PluginRegistry
 from mcp_server.settings import MCP_TRANSPORT, MCP_HOST, MCP_PORT
 
 log = logging.getLogger(__name__)
@@ -71,10 +71,12 @@ def load_yaml_plugins(registry):
 def create_mcp_server(host, port):
     """Create MCP server with settings from environment variables"""
     mcp = FastMCP("Demo", host=host, port=port, streamable_http_path="/")
-    registry = ToolRegistry(mcp)
+    registry = PluginRegistry(mcp)
     load_python_plugins(registry)
     load_python_resources(registry)
     load_yaml_plugins(registry)
+    # Publish the composed doctrine on the standard MCP `instructions` field
+    mcp._mcp_server.instructions = registry.build_instructions()
     return mcp
 
 

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -11,7 +11,7 @@ import pkgutil
 from mcp.server.fastmcp import FastMCP
 
 from mcp_server.engines import load_dataset
-from mcp_server.registry import PluginRegistry
+from mcp_server.registry import PluginsRegistry
 from mcp_server.settings import MCP_TRANSPORT, MCP_HOST, MCP_PORT
 
 log = logging.getLogger(__name__)
@@ -71,7 +71,7 @@ def load_yaml_plugins(registry):
 def create_mcp_server(host, port):
     """Create MCP server with settings from environment variables"""
     mcp = FastMCP("Demo", host=host, port=port, streamable_http_path="/")
-    registry = PluginRegistry(mcp)
+    registry = PluginsRegistry(mcp)
     load_python_plugins(registry)
     load_python_resources(registry)
     load_yaml_plugins(registry)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""
+Shared pytest fixtures for the mcp-server test suite.
+
+Fixtures defined here are auto-discovered by pytest for every test under
+``tests/`` - no import needed.
+"""
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    """Pin anyio-based async tests (those marked ``@pytest.mark.anyio``) to the
+    asyncio backend. Without this, anyio also tries the trio backend, which is
+    not installed. Consumed implicitly by the anyio plugin, not by name.
+    """
+    return "asyncio"

--- a/tests/test_registry_instructions.py
+++ b/tests/test_registry_instructions.py
@@ -1,0 +1,90 @@
+"""
+Tests for PluginRegistry.build_instructions() - the composition of the MCP
+`instructions` field (initialize result) from each plugin's self-declared
+metadata (ToolRegistry.set_plugin_info).
+
+Spec: https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle
+"""
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.memory import create_connected_server_and_client_session
+from mcp_server.registry import PluginRegistry
+
+
+class TestBuildInstructions:
+    def test_empty_when_no_plugins(self):
+        pr = PluginRegistry(FastMCP("test"))
+        assert pr.build_instructions() == ""
+
+    def test_skips_plugins_without_self_description(self):
+        # A plugin that never calls set_plugin_info contributes nothing to the
+        # prompt (repo urls alone are not persona/doctrine).
+        root = PluginRegistry(FastMCP("test"))
+        root.for_plugin("mcp_server_silent")
+        assert root.build_instructions() == ""
+
+    def test_composes_persona_description_and_questions(self):
+        root = PluginRegistry(FastMCP("test"))
+        sub = root.for_plugin("mcp_server_demo")
+        sub.set_plugin_info(
+            description="Demo datasets.",
+            instructions="You only answer about demo data.",
+            sample_questions=["What is X?", "How many Y?"],
+        )
+
+        out = root.build_instructions()
+
+        assert "You only answer about demo data." in out
+        assert "Demo datasets." in out
+        assert "What is X?" in out
+        assert "How many Y?" in out
+        # Persona is injected before the catalog description so it frames it.
+        assert out.index("You only answer about demo data.") < out.index("Demo datasets.")
+
+    def test_composes_multiple_plugins(self):
+        root = PluginRegistry(FastMCP("test"))
+        root.for_plugin("mcp_server_a").set_plugin_info(instructions="Scope A.")
+        root.for_plugin("mcp_server_b").set_plugin_info(instructions="Scope B.")
+
+        out = root.build_instructions()
+
+        assert "Scope A." in out
+        assert "Scope B." in out
+
+    def test_for_plugin_is_idempotent(self):
+        """Regression: a plugin that registers tools AND resources is handed a
+        sub-registry more than once (load_python_plugins then
+        load_python_resources). The later for_plugin() call must reuse the same
+        metadata dict, not clobber what set_plugin_info() populated on the first
+        pass - otherwise build_instructions() comes back empty.
+        """
+        root = PluginRegistry(FastMCP("test"))
+
+        # First pass: self-describe + (would) register tools.
+        first = root.for_plugin("mcp_server_dual")
+        first.set_plugin_info(description="Dual.", instructions="Scope: dual only.")
+
+        # Second pass: same plugin again (as the resources loader does).
+        second = root.for_plugin("mcp_server_dual")
+
+        # Same underlying metadata object is reused, not replaced.
+        assert first._plugin_metadata is second._plugin_metadata
+
+        out = root.build_instructions()
+        assert "Scope: dual only." in out
+        assert "Dual." in out
+
+
+@pytest.mark.anyio
+async def test_instructions_travel_in_initialize_result():
+    """End-to-end: what build_instructions() produces is what an MCP client
+    receives in the `instructions` field of the initialize handshake."""
+    mcp = FastMCP("test")
+    root = PluginRegistry(mcp)
+    root.for_plugin("mcp_server_demo").set_plugin_info(instructions="Only demo data.")
+    mcp._mcp_server.instructions = root.build_instructions()
+
+    async with create_connected_server_and_client_session(mcp._mcp_server) as client:
+        init = await client.initialize()
+
+    assert "Only demo data." in (init.instructions or "")

--- a/tests/test_registry_instructions.py
+++ b/tests/test_registry_instructions.py
@@ -1,30 +1,30 @@
 """
-Tests for PluginRegistry.build_instructions() - the composition of the MCP
+Tests for PluginsRegistry.build_instructions() - the composition of the MCP
 `instructions` field (initialize result) from each plugin's self-declared
-metadata (ToolRegistry.set_plugin_info).
+metadata (Plugin.set_plugin_info).
 
 Spec: https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle
 """
 import pytest
 from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import create_connected_server_and_client_session
-from mcp_server.registry import PluginRegistry
+from mcp_server.registry import PluginsRegistry
 
 
 class TestBuildInstructions:
     def test_empty_when_no_plugins(self):
-        pr = PluginRegistry(FastMCP("test"))
+        pr = PluginsRegistry(FastMCP("test"))
         assert pr.build_instructions() == ""
 
     def test_skips_plugins_without_self_description(self):
         # A plugin that never calls set_plugin_info contributes nothing to the
         # prompt (repo urls alone are not persona/doctrine).
-        root = PluginRegistry(FastMCP("test"))
+        root = PluginsRegistry(FastMCP("test"))
         root.for_plugin("mcp_server_silent")
         assert root.build_instructions() == ""
 
     def test_composes_persona_description_and_questions(self):
-        root = PluginRegistry(FastMCP("test"))
+        root = PluginsRegistry(FastMCP("test"))
         sub = root.for_plugin("mcp_server_demo")
         sub.set_plugin_info(
             description="Demo datasets.",
@@ -42,7 +42,7 @@ class TestBuildInstructions:
         assert out.index("You only answer about demo data.") < out.index("Demo datasets.")
 
     def test_composes_multiple_plugins(self):
-        root = PluginRegistry(FastMCP("test"))
+        root = PluginsRegistry(FastMCP("test"))
         root.for_plugin("mcp_server_a").set_plugin_info(instructions="Scope A.")
         root.for_plugin("mcp_server_b").set_plugin_info(instructions="Scope B.")
 
@@ -58,7 +58,7 @@ class TestBuildInstructions:
         metadata dict, not clobber what set_plugin_info() populated on the first
         pass - otherwise build_instructions() comes back empty.
         """
-        root = PluginRegistry(FastMCP("test"))
+        root = PluginsRegistry(FastMCP("test"))
 
         # First pass: self-describe + (would) register tools.
         first = root.for_plugin("mcp_server_dual")
@@ -80,7 +80,7 @@ async def test_instructions_travel_in_initialize_result():
     """End-to-end: what build_instructions() produces is what an MCP client
     receives in the `instructions` field of the initialize handshake."""
     mcp = FastMCP("test")
-    root = PluginRegistry(mcp)
+    root = PluginsRegistry(mcp)
     root.for_plugin("mcp_server_demo").set_plugin_info(instructions="Only demo data.")
     mcp._mcp_server.instructions = root.build_instructions()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,11 +15,6 @@ from mcp_server.server import mcp
 
 
 @pytest.fixture
-def anyio_backend():
-    return "asyncio"
-
-
-@pytest.fixture
 async def client_session() -> AsyncGenerator[ClientSession]:
     async with create_connected_server_and_client_session(mcp, raise_exceptions=True) as _session:
         yield _session


### PR DESCRIPTION
Related to https://github.com/okfn/mcp-chat-gateway/pull/38
Here we prepare the server to receive plugin _instructions_

The `ToolRegistry` was started to handle too registration.
Now we need to handle more _Plugin_ stuff. Also, we need a parent class to handle all plugins.
That why we propose two clases and the old ToolRegistry to be called directly `Plughin`, much more easy to understand
