### PR TITLE
Resoureces list as tool

### DIFF
--- a/src/mcp_server/registry.py
+++ b/src/mcp_server/registry.py
@@ -65,8 +65,11 @@ class PluginsRegistry:
             "You are a data assistant. Answer every question using at least "
             "one of the available tools; never answer factual questions from "
             "your own knowledge. If no tool fits, call the fallback tool whose "
-            "name ends in `no_tool_disponible` with a short reason. The "
-            "available tools cover these domains:"
+            "name ends in `no_tool_disponible` with a short reason. When the "
+            "user asks which resources, documents, publications or visualizers "
+            "are available (or whether a specific one exists), call the tool "
+            "whose name ends in `list_available_resources` and include its "
+            "links in the answer. The available tools cover these domains:"
         )
         return preamble + "\n\n" + "\n\n".join(blocks)
 

--- a/src/mcp_server/results.py
+++ b/src/mcp_server/results.py
@@ -10,9 +10,16 @@ from mcp.types import CallToolResult, TextContent
 
 
 def text_result(text, source_url="", table=None, charts=None, force=None):
-    """Successful response: text content plus structured sources/table/charts."""
-    # TODO: If validation model field is array, source_url should be an array as well.
-    structured = {"sources": [source_url] if source_url else []}
+    """Successful response: text content plus structured sources/table/charts.
+
+    ``source_url`` accepts a single URL (the common engine case) or a list of
+    URLs for tools whose answer draws on several sources.
+    """
+    if isinstance(source_url, (list, tuple)):
+        sources = [url for url in source_url if url]
+    else:
+        sources = [source_url] if source_url else []
+    structured = {"sources": sources}
     if table is not None:
         structured["table"] = table
     if charts:

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -13,6 +13,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp_server.engines import load_dataset
 from mcp_server.registry import PluginsRegistry
 from mcp_server.settings import MCP_TRANSPORT, MCP_HOST, MCP_PORT
+from mcp_server.tools.resources_catalog import register_core_tools
 
 log = logging.getLogger(__name__)
 
@@ -68,6 +69,16 @@ def load_yaml_plugins(registry):
             load_dataset(plugin_registry, resource)
 
 
+def load_core_tools(registry, mcp):
+    """Register server-level tools present on every instance.
+
+    Today that is the resource catalog (``core_list_available_resources``),
+    which lets the LLM answer "what resources/visualizers exist?" with links;
+    resources themselves are not autodiscovered by the model.
+    """
+    register_core_tools(registry.for_plugin("core"), mcp)
+
+
 def create_mcp_server(host, port):
     """Create MCP server with settings from environment variables"""
     mcp = FastMCP("Demo", host=host, port=port, streamable_http_path="/")
@@ -75,6 +86,7 @@ def create_mcp_server(host, port):
     load_python_plugins(registry)
     load_python_resources(registry)
     load_yaml_plugins(registry)
+    load_core_tools(registry, mcp)
     # Publish the composed doctrine on the standard MCP `instructions` field
     mcp._mcp_server.instructions = registry.build_instructions()
     return mcp

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -97,6 +97,7 @@ mcp = create_mcp_server(MCP_HOST, MCP_PORT)
 
 
 def main():
+    """ Entrypoint del server (uv run mcp-server) """
     log.info("=" * 60)
     log.info(f"Settings: host={MCP_HOST}, port={MCP_PORT} transport={MCP_TRANSPORT}")
     log.info("=" * 60)

--- a/src/mcp_server/tools/__init__.py
+++ b/src/mcp_server/tools/__init__.py
@@ -1,0 +1,5 @@
+"""Server-level (core) tools, registered on every instance regardless of
+which plugins it loads. Each module exposes a ``register_core_tools`` (or
+similarly named) function that ``server.py`` wires up under the ``core``
+namespace.
+"""

--- a/src/mcp_server/tools/resources_catalog.py
+++ b/src/mcp_server/tools/resources_catalog.py
@@ -1,0 +1,85 @@
+"""Core tool: expose the MCP resource catalog to the LLM.
+
+MCP resources (documents, PDFs, reference datasets, external visualizers)
+are not autodiscovered by the model - only tools travel through
+``tools/list``, while resources live behind ``resources/list``, which the
+chat gateway queries just for its UI panel. Without this tool a question
+like "is there a BEN data visualizer?" ends in "I don't know" even though
+the resource is registered.
+
+``list_available_resources`` closes that gap: it returns the catalog -
+name, description, type and links - as a regular tool result the model can
+quote. It is server-level on purpose so every instance (Uruguay, Brasil,
+...) gets it for free, whatever plugins it loads.
+"""
+import logging
+
+from mcp.server.fastmcp import FastMCP
+
+from mcp_server import DataToolOutput
+from mcp_server.results import text_result
+
+log = logging.getLogger(__name__)
+
+
+def _annotation_links(annotations: dict) -> list[tuple[str, str]]:
+    """Extract ``(label, url)`` pairs from a resource's annotations.
+
+    Resource annotations are free-form; by convention link-bearing keys
+    (``source_url``, ``showcase_url``, ``github_release_url``, ...) hold a
+    plain http(s) URL, so anything URL-shaped is treated as a link.
+    """
+    return [
+        (key, value)
+        for key, value in annotations.items()
+        if isinstance(value, str) and value.startswith(("http://", "https://"))
+    ]
+
+
+def register_core_tools(plugin, mcp: FastMCP) -> None:
+    """Register the server's own tools on the ``core`` namespace.
+
+    Args:
+        plugin: Namespaced registry (``registry.for_plugin("core")``).
+        mcp: The shared FastMCP server, queried for the resource catalog.
+    """
+
+    @plugin.tool()
+    async def list_available_resources() -> DataToolOutput:
+        """List every complementary resource this server offers: documents,
+            publications (PDF), reference datasets and external visualizers,
+            each with its description and links.
+
+            Use this tool whenever the user asks which resources, documents,
+            publications, books or visualizers exist or are available, or
+            whether a specific one exists (e.g. "is there a data visualizer
+            for X?", "where can I download the annual report?").
+            Answer in the user's language and always include the links.
+
+        Examples:
+            - list_available_resources()
+        """
+        resources = await mcp.list_resources()
+        if not resources:
+            return text_result("This server has no complementary resources registered.")
+
+        lines = [f"{len(resources)} complementary resource(s) available on this server:", ""]
+        sources = []
+        for res in resources:
+            meta = res.meta or {}
+            links = _annotation_links(meta.get("annotations") or {})
+
+            details = [d for d in (res.mimeType, meta.get("plugin")) if d]
+            header = f"- {res.name or res.uri}"
+            if details:
+                header += f" ({', '.join(details)})"
+            lines.append(header)
+            if res.description:
+                lines.append(f"  {res.description}")
+            lines.append(f"  URI: {res.uri}")
+            for label, url in links:
+                lines.append(f"  {label}: {url}")
+                sources.append(url)
+            lines.append("")
+
+        return text_result("\n".join(lines).rstrip(), source_url=sources)

--- a/tests/test_core_tools.py
+++ b/tests/test_core_tools.py
@@ -1,0 +1,88 @@
+"""
+Tests for the server-level core tools (src/mcp_server/tools/).
+
+Today that is ``core_list_available_resources`` (from the core function
+``list_available_resources``): the LLM does not
+autodiscover MCP resources (only tools travel through tools/list), so this
+tool is what lets the model answer "what resources/visualizers exist?"
+with links.
+"""
+from collections.abc import AsyncGenerator
+
+import pytest
+from mcp.client.session import ClientSession
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mcp_server.registry import PluginsRegistry
+from mcp_server.tools.resources_catalog import register_core_tools
+
+
+def build_server_with_resources() -> FastMCP:
+    """A server with one plugin resource, mirroring how a real plugin
+    declares an external reference link (text/uri-list)."""
+    mcp = FastMCP("test")
+    registry = PluginsRegistry(mcp)
+    plugin = registry.for_plugin("mcp_server_demo")
+
+    @plugin.resource(
+        "some_ref/some_name",
+        name="MCP Resource Name",
+        description="Some link to a reference website.",
+        mime_type="text/uri-list",
+        annotations={
+            "publisher": "Some publisher",
+            "showcase_url": "https://example.org/showcase/ref-name",
+        },
+    )
+    def reference_link() -> str:
+        return "https://example.org/showcase/ref-name\n"
+
+    register_core_tools(registry.for_plugin("core"), mcp)
+    return mcp
+
+
+@pytest.fixture
+async def client_session() -> AsyncGenerator[ClientSession]:
+    async with create_connected_server_and_client_session(
+        build_server_with_resources(), raise_exceptions=True
+    ) as session:
+        yield session
+
+
+@pytest.mark.anyio
+async def test_catalog_tool_is_registered_under_core_namespace(client_session: ClientSession):
+    tools = await client_session.list_tools()
+    assert "core_list_available_resources" in [t.name for t in tools.tools]
+
+
+@pytest.mark.anyio
+async def test_catalog_lists_resources_with_links(client_session: ClientSession):
+    result = await client_session.call_tool("core_list_available_resources", {})
+
+    assert not result.isError
+    text = result.content[0].text
+    # Name, description, plugin, URI and annotation links all surface so the
+    # LLM can answer "is there a visualizer?" and quote the link.
+    assert "MCP Resource Name" in text
+    assert "Some link to a reference website" in text
+    assert "mcp_server_demo" in text
+    assert "mcp://mcp_server_demo/some_ref/some_name" in text
+    assert "showcase_url: https://example.org/showcase/ref-name" in text
+    # Links also land in structuredContent.sources for the gateway UI.
+    assert result.structuredContent["sources"] == [
+        "https://example.org/showcase/ref-name"
+    ]
+
+
+@pytest.mark.anyio
+async def test_catalog_with_no_resources():
+    mcp = FastMCP("test")
+    registry = PluginsRegistry(mcp)
+    register_core_tools(registry.for_plugin("core"), mcp)
+
+    async with create_connected_server_and_client_session(mcp, raise_exceptions=True) as session:
+        result = await session.call_tool("core_list_available_resources", {})
+
+    assert not result.isError
+    assert "no complementary resources" in result.content[0].text


### PR DESCRIPTION
Add core tool that lists plugin registered resources, so we can answer "what resources exist?" with links

<img width="3785" height="1491" alt="image" src="https://github.com/user-attachments/assets/bf48e637-fa98-43cd-8e62-3dec6670bd5f" />

Also, previous pending fix was solved (sources with lists)